### PR TITLE
update build

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,7 +1,7 @@
 # -*- toml -*-
 
 [packages]
-toml = "*"
+tomli = "*"
 wheel = "*"
 
 "kt.appackager" = {path = ".", editable = true}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,34 +1,38 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "33b051fe5a526f6d8db82af564b19e7fd709a5c0031101596161b3045db48c3b"
+            "sha256": "1b7e5d44754d09645532a13ed859a2df9abdf0c5a7a3448013b6ecda604a8ba2"
         },
         "pipfile-spec": 6,
         "requires": {},
         "sources": [
             {
-                "url": "https://keeper:Keeper1SS@devpi.keepertech.com/keeper/prod/+simple/"
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
             }
         ]
     },
     "default": {
-        "kt.appackager": {
+        "kt-appackager": {
             "editable": true,
             "path": "."
         },
-        "toml": {
+        "tomli": {
             "hashes": [
-                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "version": "==0.10.2"
+            "index": "pypi",
+            "version": "==2.0.1"
         },
         "wheel": {
             "hashes": [
-                "sha256:78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e",
-                "sha256:e11eefd162658ea59a60a0f6c7d493a7190ea4b9a85e335b33489d9f17e0245e"
+                "sha256:cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873",
+                "sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247"
             ],
-            "version": "==0.36.2"
+            "index": "pypi",
+            "version": "==0.40.0"
         }
     },
     "develop": {}

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,12 @@ Release history
 
 #. Store last alpha for each base version, to better support switching
    branches in working copy.
+#. Switch to ``tomli`` for TOML parsing; older ``toml`` library appears
+   to have disappeared.
+#. Remove "kt-" from package name.
+#. Update supported Python versions.
+#. Avoid deprecation warnings from updated packaging libraries.
+#. Excise nothing by default.
 
 
 0.6.2 (2022-09-23)

--- a/appackager.toml
+++ b/appackager.toml
@@ -1,7 +1,7 @@
 
 [package]
 # Name of operating system package
-name = "kt-appackager"
+name = "appackager"
 
 description = "Keeper Technology application builder."
 maintainer = "Keeper Technology LLC"
@@ -14,14 +14,14 @@ maintainer = "Keeper Technology LLC"
 
 requires = [
   "dpkg-dev",
-  "kt-python39",
+  "cleanpython311",
   "lsb-release",
 ]
 
 
 [installation]
 directory = "/opt/appackager"
-python = "/opt/kt-python39/bin/python3"
+python = "/opt/cleanpython311/bin/python3"
 
 
 [script.appackage]

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,9 @@ metadata = dict(
     description=__doc__,
     packages=['kt.appackager'],
     package_dir={'': 'src'},
-    namespace_packages=['kt'],
     include_package_data=True,
     install_requires=[
-        'toml',
+        'tomli',
         'wheel',
     ],
     entry_points={
@@ -28,11 +27,12 @@ metadata = dict(
     },
     classifiers=[
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )
 

--- a/src/kt/appackager/build.py
+++ b/src/kt/appackager/build.py
@@ -19,7 +19,7 @@ import sys
 import tempfile
 import textwrap
 
-import toml
+import tomli
 
 import kt.appackager.cli
 
@@ -428,8 +428,10 @@ class Build(object):
                 site_packages = os.path.dirname(os.path.dirname(appackagerdir))
                 with tempfile.TemporaryDirectory() as tmpdir:
                     subprocess.check_call(
-                        [self.config.python, 'setup.py', '-q',
-                         'dist_info', '--egg-base', tmpdir],
+                        # sys.executable here is from the running appackager
+                        # build, so includes the required wheel support:
+                        [sys.executable, 'setup.py', '-q',
+                         'dist_info', '--output-dir', tmpdir],
                         env={'PYTHONPATH': site_packages})
                     dist_info = os.path.join(tmpdir, os.listdir(tmpdir)[0])
                     with open(os.path.join(dist_info, 'METADATA')) as f:
@@ -453,7 +455,8 @@ class Build(object):
                     found = 'in setup.cfg'
 
             elif os.path.exists('pyproject.toml'):
-                conf = toml.load('pyproject.toml')
+                with open('pyproject.toml', 'rb') as ppf:
+                    conf = tomli.load(ppf)
                 project = conf.get('project')
                 if isinstance(project, dict):
                     name = project.get('name')

--- a/src/kt/appackager/cli.py
+++ b/src/kt/appackager/cli.py
@@ -6,7 +6,7 @@ Command-line & configuration-loading support.
 import argparse
 import logging
 
-import toml
+import tomli
 
 
 DEFAULT_AUTOVERSION_FILE = '.autoversion.json'
@@ -29,7 +29,8 @@ class ArgumentParser(argparse.ArgumentParser):
     def parse_args(self):
         self.add_argument('settings', nargs="*")
         namespace = super(ArgumentParser, self).parse_args()
-        namespace.config = Configuration(toml.load(namespace.configuration))
+        with open(namespace.configuration, 'rb') as cf:
+            namespace.config = Configuration(tomli.load(cf))
         return namespace
 
 
@@ -58,7 +59,7 @@ class Configuration(object):
         self.directory = self._get('installation', 'directory')
         self.packages_to_excise = self._get('installation', 'excise-packages',
                                             type='array',
-                                            default=['pip', 'setuptools'])
+                                            default=[])
         self.python = self._get('installation', 'python')
 
         self.hook_scripts = self._get('package', 'hook-scripts',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,coverage-report
+envlist = cpy37,cpy38,cpy39,cpy310,cpy311,coverage-report
 skip_missing_interpreters = true
 
 [testenv]
@@ -8,26 +8,25 @@ commands =
     python -Werror::DeprecationWarning -m coverage \
         run --parallel-mode -m unittest discover
 
-install_command =
-    pip install \
-        --index-url \
-        https://keeper:Keeper1SS@devpi.keepertech.com/keeper/prod/+simple/ \
-        {opts} {packages}
+install_command = pip install {opts} {packages}
 
-[testenv:py36]
-basepython = /opt/kt-python36/bin/python3
+[testenv:cpy37]
+basepython = /opt/cleanpython37/bin/python3
 
-[testenv:py37]
-basepython = /opt/kt-python37/bin/python3
+[testenv:cpy38]
+basepython = /opt/cleanpython38/bin/python3
 
-[testenv:py38]
-basepython = /opt/kt-python38/bin/python3
+[testenv:cpy39]
+basepython = /opt/cleanpython39/bin/python3
 
-[testenv:py39]
-basepython = /opt/kt-python39/bin/python3
+[testenv:cpy310]
+basepython = /opt/cleanpython310/bin/python3
 
-[testenv:py310]
-basepython = /opt/kt-python310/bin/python3
+[testenv:cpy311]
+basepython = /opt/cleanpython311/bin/python3
+
+[testenv:cpy312]
+basepython = /opt/cleanpython312/bin/python3
 
 [testenv:coverage-report]
 deps =


### PR DESCRIPTION
- replace outdated toml package with tomli
- remove "kt-" from package name
- switch from "kt-python" to more generic "cleanpython" name
- update supported python versions
- avoid deprecation warnings from more modern packaging tools
- excise nothing by default
- remove additional reference to private repository